### PR TITLE
Fix double instantiation and execution of Angular controllers

### DIFF
--- a/single/src/main/resources/static/home.html
+++ b/single/src/main/resources/static/home.html
@@ -1,5 +1,5 @@
 <h1>Greeting</h1>
-<div ng-controller="home" ng-show="authenticated">
+<div ng-show="authenticated">
 	<p>The ID is {{greeting.id}}</p>
 	<p>The content is {{greeting.content}}</p>
 </div>

--- a/single/src/main/resources/static/index.html
+++ b/single/src/main/resources/static/index.html
@@ -13,14 +13,16 @@
 </head>
 
 <body ng-app="hello" ng-cloak class="ng-cloak">
-	<div ng-controller="navigation" class="container">
+	<div ng-controller="navigation">
+        <div class="container">
 		<ul class="nav nav-pills" role="tablist">
 			<li ng-class="{active:tab('home')}"><a href="#/">home</a></li>
 			<li><a href="#/login">login</a></li>
 			<li ng-show="authenticated"><a href="" ng-click="logout()">logout</a></li>
 		</ul>
+        </div>
+        <div ng-view class="container"></div>
 	</div>
-	<div ng-view class="container"></div>
 	<script src="js/angular-bootstrap.js" type="text/javascript"></script>
 	<script src="js/hello.js"></script>
 </body>

--- a/single/src/main/resources/static/js/hello.js
+++ b/single/src/main/resources/static/js/hello.js
@@ -4,8 +4,7 @@ angular.module('hello', [ 'ngRoute' ]).config(function($routeProvider) {
 		templateUrl : 'home.html',
 		controller : 'home'
 	}).when('/login', {
-		templateUrl : 'login.html',
-		controller : 'navigation'
+		templateUrl : 'login.html'
 	}).otherwise('/');
 
 }).controller('navigation',


### PR DESCRIPTION
The controller gets attached to the view by default when you use ngRoute with the ng-view directive. No need to attach it in the template. In the logs, you can see that the home controller fetches the '/resource' twice...

[Angular docs](https://docs.angularjs.org/api/ng/directive/ngController) :  
Note that you can also attach controllers to the DOM by declaring it in a route definition via the $route service. **A common mistake is to declare the controller again using ng-controller in the template itself. This will cause the controller to be attached and executed twice.**
