### PR TITLE
update spring-cloud-starter-parent to current 1.0.0 release

### DIFF
--- a/oauth2-vanilla/resource/pom.xml
+++ b/oauth2-vanilla/resource/pom.xml
@@ -23,7 +23,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-parent</artifactId>
-				<version>1.0.0.RC3</version>
+				<version>1.0.0.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/oauth2-vanilla/ui/pom.xml
+++ b/oauth2-vanilla/ui/pom.xml
@@ -23,7 +23,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-parent</artifactId>
-				<version>1.0.0.BUILD-SNAPSHOT</version>
+				<version>1.0.0.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/oauth2/resource/pom.xml
+++ b/oauth2/resource/pom.xml
@@ -23,7 +23,7 @@
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
 				<artifactId>spring-cloud-starter-parent</artifactId>
-				<version>1.0.0.RC3</version>
+				<version>1.0.0.RELEASE</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>


### PR DESCRIPTION
Just an update to match the current versions
