### PR TITLE
Fix #89 by upgrading plugin versions

### DIFF
--- a/oauth2/resource/pom.xml
+++ b/oauth2/resource/pom.xml
@@ -80,12 +80,12 @@
 				<dependency>
 					<groupId>org.codehaus.groovy</groupId>
 					<artifactId>groovy-eclipse-compiler</artifactId>
-					<version>2.8.0-01</version>
+					<version>2.9.0-01</version>
 				</dependency>
 				<dependency>
 					<groupId>org.codehaus.groovy</groupId>
 					<artifactId>groovy-eclipse-batch</artifactId>
-					<version>2.1.8-01</version>
+					<version>2.3.7-01</version>
 				</dependency>
 				</dependencies>
 			</plugin>


### PR DESCRIPTION
According to http://stackoverflow.com/a/25361483/1098564, 

> Older versions do not support Java 1.8 and newer Groovy.
