### PR TITLE
Fixed typo in JS code example in single/README.adoc

### DIFF
--- a/single/README.adoc
+++ b/single/README.adoc
@@ -172,7 +172,7 @@ angular.module('hello', [ 'ngRoute' ]) // ... omitted code
         + btoa(credentials.username + ":" + credentials.password)
     } : {};
 
-    $http.get('user', {headers : headers}).then(function(response.data) {
+    $http.get('user', {headers : headers}).then(function(response) {
       if (response.data.name) {
         $rootScope.authenticated = true;
       } else {


### PR DESCRIPTION
Small typo in tutorial text, on the chapter "Submitting the Login Form",  example code from hello.js contains line:
`$http.get('user', {headers : headers}).then(function(response.data) {`
which should obviously be like in the actual code contained in the git repo:
`$http.get('user', {headers : headers}).then(function(response) {`
