### PR TITLE
Serve "/user" without authentication

### DIFF
--- a/single/src/main/java/demo/UiApplication.java
+++ b/single/src/main/java/demo/UiApplication.java
@@ -56,7 +56,7 @@ public class UiApplication {
 		@Override
 		protected void configure(HttpSecurity http) throws Exception {
 			http.httpBasic().and().authorizeRequests()
-					.antMatchers("/index.html", "/home.html", "/login.html", "/").permitAll().anyRequest()
+					.antMatchers("/index.html", "/home.html", "/login.html", "/user", "/").permitAll().anyRequest()
 					.authenticated().and().csrf()
 					.csrfTokenRepository(csrfTokenRepository()).and()
 					.addFilterAfter(csrfHeaderFilter(), CsrfFilter.class);


### PR DESCRIPTION
Right now browser throws "401 unauthorized" error when doing $http.get('user'). "/user" should be accessible to unauthorized user in order to return response so that $rootScope.authenticated = false; may be executed
