### PR TITLE
DRYing the webjars versions in leaf projects

### DIFF
--- a/basic/README.adoc
+++ b/basic/README.adoc
@@ -29,7 +29,7 @@ The easiest way to create a new project to get started is via the https://start.
 ----
 $ mkdir ui && cd ui
 $ curl https://start.spring.io/starter.tgz -d style=web \
--d style=security -d name=ui | tar -xzvf - 
+-d style=security -d name=ui | tar -xzvf -
 ----
 
 You can then import that project (it's a normal Maven Java project by default) into your favourite IDE, or just work with the files and "mvn" on the command line. Then jump to the link:#add-a-home-page[next section].
@@ -170,27 +170,27 @@ To create static resources at build time we add some magic to the Maven `pom.xml
       </executions>
       <configuration>
         <wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-        <cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-        <jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-        <wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-        <extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-        <contextFolder>${basedir}/src/main/wro</contextFolder>
+        <cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+        <jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+        <wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+        <extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+        <contextFolder>${project.build.directory}/wro</contextFolder>
       </configuration>
       <dependencies>
         <dependency>
           <groupId>org.webjars</groupId>
           <artifactId>jquery</artifactId>
-          <version>2.2.4</version>
+          <version>${jquery.version}</version>
         </dependency>
         <dependency>
           <groupId>org.webjars</groupId>
           <artifactId>angularjs</artifactId>
-          <version>1.4.9</version>
+          <version>${angularjs.version}</version>
         </dependency>
         <dependency>
           <groupId>org.webjars</groupId>
           <artifactId>bootstrap</artifactId>
-          <version>3.3.7</version>
+          <version>${bootstrap.version}</version>
         </dependency>
       </dependencies>
     </plugin>
@@ -232,9 +232,9 @@ postProcessors=less4j,jsMin
 ----
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-  <css>webjar:bootstrap/3.3.7/less/bootstrap.less</css>   
+  <css>webjar:bootstrap/3.3.7/less/bootstrap.less</css>
     <css>file:./src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
+    <js>webjar:jquery/${jquery.version}/jquery.min.js</js>
     <js>webjar:angularjs/1.4.9/angular.min.js</js>
   </group>
 </groups>

--- a/basic/pom.xml
+++ b/basic/pom.xml
@@ -35,25 +35,60 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>angularjs</artifactId>
-			<version>1.4.9</version>
+			<version>${angularjs.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jasmine</artifactId>
-			<version>2.0.0</version>
+			<version>${jasmine.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<wro4j.version>1.8.0</wro4j.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -72,27 +107,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>
@@ -111,12 +146,12 @@
 					<additionalContexts>
 						<context>
 							<contextRoot>/lib</contextRoot>
-							<directory>${project.build.directory}/classes/static/js</directory>
+							<directory>${project.build.directory}/generated-resources/static/js</directory>
 						</context>
 					</additionalContexts>
 					<preloadSources>
 						<source>/lib/angular-bootstrap.js</source>
-						<source>/webjars/angularjs/1.4.9/angular-mocks.js</source>
+						<source>/webjars/angularjs/${angularjs.version}/angular-mocks.js</source>
 					</preloadSources>
 					<jsSrcDir>${project.basedir}/src/main/resources/static/js</jsSrcDir>
 					<jsTestSrcDir>${project.basedir}/src/test/resources/static/js</jsTestSrcDir>

--- a/basic/src/main/wro/wro.xml
+++ b/basic/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+	<css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/double/admin/pom.xml
+++ b/double/admin/pom.xml
@@ -51,6 +51,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
@@ -63,6 +67,29 @@
 			</resource>
 		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -83,25 +110,25 @@
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
 					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
 					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/double/admin/src/main/wro/wro.xml
+++ b/double/admin/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="admin-assets">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/double/gateway/pom.xml
+++ b/double/gateway/pom.xml
@@ -78,6 +78,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
@@ -90,6 +94,29 @@
 			</resource>
 		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -110,25 +137,25 @@
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
 					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
 					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/double/gateway/src/main/wro/wro.xml
+++ b/double/gateway/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="gateway-assets">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/double/ui/pom.xml
+++ b/double/ui/pom.xml
@@ -51,10 +51,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -73,27 +108,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/double/ui/src/main/wro/wro.xml
+++ b/double/ui/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/modular/pom.xml
+++ b/modular/pom.xml
@@ -52,6 +52,10 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
@@ -64,6 +68,29 @@
 			</resource>
 		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -84,25 +111,25 @@
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
 					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
 					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/modular/src/main/wro/wro.xml
+++ b/modular/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-    <css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/oauth2-vanilla/ui/pom.xml
+++ b/oauth2-vanilla/ui/pom.xml
@@ -74,10 +74,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -96,27 +131,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/oauth2-vanilla/ui/src/main/wro/wro.xml
+++ b/oauth2-vanilla/ui/src/main/wro/wro.xml
@@ -1,9 +1,9 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.js</js>
-    <js>webjar:angularjs/1.4.9/angular.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
    </group>
 </groups>

--- a/oauth2/authserver/pom.xml
+++ b/oauth2/authserver/pom.xml
@@ -60,6 +60,10 @@
 		<start-class>demo.AuthserverApplication</start-class>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
@@ -72,6 +76,29 @@
 			</resource>
 		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -92,20 +119,20 @@
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
 					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
 					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/oauth2/authserver/src/main/wro/wro.xml
+++ b/oauth2/authserver/src/main/wro/wro.xml
@@ -1,7 +1,7 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="wro">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
-    <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
+      <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
+      <css>file:@project.basedir@/src/main/wro/main.less</css>
+      <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
    </group>
 </groups>

--- a/oauth2/ui/pom.xml
+++ b/oauth2/ui/pom.xml
@@ -78,10 +78,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -100,27 +135,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/oauth2/ui/src/main/wro/wro.xml
+++ b/oauth2/ui/src/main/wro/wro.xml
@@ -1,9 +1,9 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
    </group>
 </groups>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
 		<module>double</module>
 		<module>modular</module>
 	</modules>
-	
-    <build>
+
+	<build>
       <plugins>
       </plugins>
     </build>

--- a/proxy/ui/pom.xml
+++ b/proxy/ui/pom.xml
@@ -78,10 +78,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -100,27 +135,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/proxy/ui/src/main/wro/wro.xml
+++ b/proxy/ui/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/single/pom.xml
+++ b/single/pom.xml
@@ -40,13 +40,13 @@
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>angularjs</artifactId>
-			<version>1.4.9</version>
+			<version>${angularjs.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.webjars</groupId>
 			<artifactId>jasmine</artifactId>
-			<version>2.4.1</version>
+			<version>${jasmine.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
@@ -55,10 +55,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -77,27 +112,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/single/src/main/wro/wro.xml
+++ b/single/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-    <css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>
-    <css>file:./src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
+    <css>file:@project.basedir@/src/main/wro/main.less</css>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/spring-session/ui/pom.xml
+++ b/spring-session/ui/pom.xml
@@ -51,10 +51,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -73,27 +108,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/spring-session/ui/src/main/wro/wro.xml
+++ b/spring-session/ui/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>

--- a/vanilla/ui/pom.xml
+++ b/vanilla/ui/pom.xml
@@ -43,10 +43,45 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<wro4j.version>1.8.0</wro4j.version>
 		<java.version>1.8</java.version>
+		<angularjs.version>1.4.9</angularjs.version>
+		<bootstrap.version>3.3.7-1</bootstrap.version>
+		<jquery.version>2.2.4</jquery.version>
+		<jasmine.version>2.0.0</jasmine.version>
 	</properties>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>${project.basedir}/src/main/resources</directory>
+			</resource>
+			<resource>
+				<directory>${project.build.directory}/generated-resources</directory>
+			</resource>
+		</resources>
 		<plugins>
+			<plugin>
+				<artifactId>maven-resources-plugin</artifactId>
+				<executions>
+					<execution>
+						<!-- Serves *only* to filter the wro.xml so it can get an absolute
+                          path for the project -->
+						<id>copy-resources</id>
+						<phase>validate</phase>
+						<goals>
+							<goal>copy-resources</goal>
+						</goals>
+						<configuration>
+							<outputDirectory>${basedir}/target/wro</outputDirectory>
+							<resources>
+								<resource>
+									<directory>src/main/wro</directory>
+									<filtering>true</filtering>
+								</resource>
+							</resources>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
@@ -65,27 +100,27 @@
 				</executions>
 				<configuration>
 					<wroManagerFactory>ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory</wroManagerFactory>
-					<cssDestinationFolder>${project.build.directory}/classes/static/css</cssDestinationFolder>
-					<jsDestinationFolder>${project.build.directory}/classes/static/js</jsDestinationFolder>
-					<wroFile>${basedir}/src/main/wro/wro.xml</wroFile>
-					<extraConfigFile>${basedir}/src/main/wro/wro.properties</extraConfigFile>
-					<contextFolder>${basedir}/src/main/wro</contextFolder>
+					<cssDestinationFolder>${project.build.directory}/generated-resources/static/css</cssDestinationFolder>
+					<jsDestinationFolder>${project.build.directory}/generated-resources/static/js</jsDestinationFolder>
+					<wroFile>${project.build.directory}/wro/wro.xml</wroFile>
+					<extraConfigFile>${project.build.directory}/wro/wro.properties</extraConfigFile>
+					<contextFolder>${project.build.directory}/wro</contextFolder>
 				</configuration>
 				<dependencies>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>jquery</artifactId>
-						<version>2.2.4</version>
+						<version>${jquery.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>angularjs</artifactId>
-						<version>1.4.9</version>
+						<version>${angularjs.version}</version>
 					</dependency>
 					<dependency>
 						<groupId>org.webjars</groupId>
 						<artifactId>bootstrap</artifactId>
-						<version>3.3.7-1</version>
+						<version>${bootstrap.version}</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/vanilla/ui/src/main/wro/wro.xml
+++ b/vanilla/ui/src/main/wro/wro.xml
@@ -1,10 +1,10 @@
 <groups xmlns="http://www.isdc.ro/wro">
   <group name="angular-bootstrap">
-	<css>webjar:bootstrap/3.3.7-1/less/bootstrap.less</css>   
+    <css>webjar:bootstrap/@bootstrap.version@/less/bootstrap.less</css>
     <css>file:@project.basedir@/src/main/wro/main.less</css>
-    <js>webjar:jquery/2.2.4/jquery.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-route.min.js</js>
-    <js>webjar:angularjs/1.4.9/angular-cookies.min.js</js>
+    <js>webjar:jquery/@jquery.version@/jquery.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-route.min.js</js>
+    <js>webjar:angularjs/@angularjs.version@/angular-cookies.min.js</js>
    </group>
 </groups>


### PR DESCRIPTION
Hi guys,
thanks for your great job at explaining me what this Spring Boot + AngulasJS was all about!

I felt I could pay you back with a little help: DRYing webjars versions.

Indeed, first version of the tutorial shows a nice mechanism to filter properties in wro4J file but the Github version gets rid of that nice feature, probably to correct previous compatibility issues with bootstrap CSS files.

In this pull request, I suggest creating jquery, bootstrap and AngularJS versions in one place, Maven properties, and then take advantage of the neat Spring filtering @variable@ to inject versions.

This way, versions for webjars are defined once and for all, and injected magically by Spring.

And my IntelliJ IDEA now can resolve the CSS and JS files since they are present in the generated-resources folder! (makes me happy when IntelliJ stops complaining)

Some notes about the correction:

1- Some wro.xml files were not processing the main.less file since there was still the @project.basedir@ mention in it
2- I fought myself not to promote the properties to the root pom.xml (I guess it was more convenient for tutorial scoping/chunking to have it defined in leaf projects)
3- I changed the Wro configuration folder to become the ${project.build.directory}/wro since once the resources plugin kicks in, we have everything filtered there.

Hope this helps you keeping up with your good work.

Thanks again!