### PR TITLE
Fix zuul routes to resource in oauth2 and oauth2-logout

### DIFF
--- a/oauth2-logout/ui/src/main/resources/application.yml
+++ b/oauth2-logout/ui/src/main/resources/application.yml
@@ -23,7 +23,7 @@ zuul:
   routes:
     resource:
       path: /resource/**
-      url: http://localhost:9000/resource
+      url: http://localhost:9000
     user:
       path: /user/**
       url: http://localhost:9999/uaa/user

--- a/oauth2/ui/src/main/resources/application.yml
+++ b/oauth2/ui/src/main/resources/application.yml
@@ -23,7 +23,7 @@ zuul:
   routes:
     resource:
       path: /resource/**
-      url: http://localhost:9000/resource
+      url: http://localhost:9000
     user:
       path: /user/**
       url: http://localhost:9999/uaa/user


### PR DESCRIPTION
Inside the resource modules of oauth2 and oauth2-logout the path to the resource is "/" not "/resource". In the oauth2-vanilla the application.yml does contain the correct path.