### PR TITLE
Fixing authenticating user on page reload ({} is resolved to truthy)

### DIFF
--- a/single/src/app/app.component.ts
+++ b/single/src/app/app.component.ts
@@ -11,7 +11,7 @@ import 'rxjs/add/operator/finally';
 })
 export class AppComponent {
   constructor(private app: AppService, private http: HttpClient, private router: Router) {
-      this.app.authenticate({}, undefined);
+      this.app.authenticate(undefined, undefined);
     }
     logout() {
       this.http.post('logout', {}).finally(() => {


### PR DESCRIPTION
Module: single
Issue: When client opens the app in a browser, the authentication is performed by calling authenticate() with empty object: {}, but such objects are resolved as truthy in conditional expressions, thus authentication header  is sent  with invalid user/password (i.e. btoa(undefined+':'+undefined)) whenever page is reloaded. The solution is to not send the auth header and allow the server to confirm credentials basing on cookies.