### PR TITLE
fix wrong *.component.js references

### DIFF
--- a/double/README.adoc
+++ b/double/README.adoc
@@ -413,7 +413,7 @@ NOTE: the role names come back from the "/user" endpoint with the "ROLE_" prefix
 
 We are going to use the roles to make access decisions in the Gateway as well (so we can conditionally display a link to the admin UI), so we should add the "roles" to the "/user" endpoint in the Gateway as well. Once that is in place we can add some JavaScript to set up a flag to indicate that the current user is an "ADMIN". In the `authenticated()` function:
 
-.app.component.js
+.app.component.ts
 [source,javascript]
 ----
 this.http.get('user', {headers: headers}).subscribe(data => {

--- a/single/README.adoc
+++ b/single/README.adoc
@@ -127,7 +127,7 @@ Since the user now has the choice whether to login or not (before it was all con
 
 The `HomeComponent` has to fetch the greeting, and also provide the `authenticated()` utility function that pulls the flag out of the `AppService`:
 
-.home.component.js
+.home.component.ts
 [source,javascript]
 ----
 include::src/app/home.component.ts[indent=0]

--- a/vanilla/README.adoc
+++ b/vanilla/README.adoc
@@ -33,7 +33,7 @@ export class HomeComponent {
 
 All we need to do to this is change the URL. For example, if we are going to run the new resource on localhost, it could look like this:
 
-.home.component.js
+.home.component.ts
 [source,javascript]
 ----
         http.get('http://localhost:9000').subscribe(data => this.greeting = data);
@@ -208,7 +208,7 @@ TIP: if you don't have a redis server running locally you can easily spin one up
 
 The only missing piece is the transport mechanism for the key to the data in the store. The key is the `HttpSession` ID, so if we can get hold of that key in the UI client, we can send it as a custom header to the resource server. So the "home" controller would need to change so that it sends the header as part of the HTTP request for the greeting resource. For example:
 
-.home.component.js
+.home.component.ts
 [source,javascript]
 ----
   constructor(private app: AppService, private http: HttpClient) {


### PR DESCRIPTION
not really something important but when following the guide I noticed some of it is referring to some .js files that don't exist. some others are correctly referencing the typescript files so I think this must be a typo or some old references