### PR TITLE
Migrate to spring boot 2.0.1.RELEASE

### DIFF
--- a/single/pom.xml
+++ b/single/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>1.5.6.RELEASE</version>
+        <version>2.0.1.RELEASE</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 

--- a/single/src/main/java/demo/UiApplication.java
+++ b/single/src/main/java/demo/UiApplication.java
@@ -1,10 +1,5 @@
 package demo;
 
-import java.security.Principal;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
-
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
@@ -17,50 +12,55 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 
+import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 @SpringBootApplication
 @Controller
 public class UiApplication {
 
-    @GetMapping("/user")
-    @ResponseBody
-    public Principal user(Principal user) {
-        return user;
-    }
+  @GetMapping("/user")
+  @ResponseBody
+  public Principal user(Principal user) {
+    return user;
+  }
 
-    @GetMapping("/resource")
-    @ResponseBody
-    public Map<String, Object> home() {
-        Map<String, Object> model = new HashMap<String, Object>();
-        model.put("id", UUID.randomUUID().toString());
-        model.put("content", "Hello World");
-        return model;
-    }
+  @GetMapping("/resource")
+  @ResponseBody
+  public Map<String, Object> home() {
+    Map<String, Object> model = new HashMap<String, Object>();
+    model.put("id", UUID.randomUUID().toString());
+    model.put("content", "Hello World");
+    return model;
+  }
 
-    @GetMapping(value = "/{path:[^\\.]*}")
-    public String redirect() {
-        return "forward:/";
-    }
+  @GetMapping(value = "/{path:[^\\.]*}")
+  public String redirect() {
+    return "forward:/";
+  }
 
-    public static void main(String[] args) {
-        SpringApplication.run(UiApplication.class, args);
-    }
+  public static void main(String[] args) {
+    SpringApplication.run(UiApplication.class, args);
+  }
 
-    @Configuration
-    @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
-    protected static class SecurityConfiguration extends WebSecurityConfigurerAdapter {
-        @Override
-        protected void configure(HttpSecurity http) throws Exception {
-            // @formatter:off
-            http
-                .httpBasic().and()
-                .authorizeRequests()
-                    .antMatchers("/index.html", "/", "/home", "/login").permitAll()
-                    .anyRequest().authenticated()
-                    .and()
-                .csrf()
-                    .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
-            // @formatter:on
-        }
+  @Configuration
+  @Order(SecurityProperties.BASIC_AUTH_ORDER - 10)
+  protected static class SecurityConfiguration extends WebSecurityConfigurerAdapter {
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+      // @formatter:off
+      http
+        .httpBasic().and()
+        .authorizeRequests()
+        .antMatchers("/index.html", "/", "/home", "/login").permitAll()
+        .anyRequest().authenticated()
+        .and()
+        .csrf()
+        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse());
+      // @formatter:on
     }
+  }
 
 }

--- a/single/src/main/resources/application.yml
+++ b/single/src/main/resources/application.yml
@@ -1,8 +1,9 @@
-security:
-  user:
-    password: password
-  ignored:
-  - "*.bundle.*"
+spring:
+  security:
+    user:
+      password: password
+    ignored:
+    - "*.bundle.*"
 logging:
   level:
     org.springframework.security: DEBUG

--- a/single/src/test/java/demo/ApplicationTests.java
+++ b/single/src/test/java/demo/ApplicationTests.java
@@ -4,10 +4,10 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.context.embedded.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -47,6 +47,7 @@ public class ApplicationTests {
 		TestRestTemplate template = new TestRestTemplate("user", "password");
 		ResponseEntity<String> response = template.getForEntity("http://localhost:" + port
 				+ "/user", String.class);
+		System.out.println(response.getStatusCode());
 		assertEquals(HttpStatus.OK, response.getStatusCode());
 	}
 


### PR DESCRIPTION
Respect to #179 , this is a migration.  
Compared to the last version of spring boot adopt, the main changes are:
- configuration file(s), usually located at `application.properties`
- API changes(One Annotation changed at [LocalServerPort](https://github.com/ArvinSiChuan/tut-spring-security-and-angular-js/commit/511613148c9ded80c5ed4fed1b04b8d2c26f6366#diff-5602a68eca5d22a0749e384100a4d9f5R10) and one enum attribute at [SecurityProperties](https://github.com/ArvinSiChuan/tut-spring-security-and-angular-js/commit/511613148c9ded80c5ed4fed1b04b8d2c26f6366#diff-411cf435c6bbf48b2001e9655aed4b44R49))