### PR TITLE
Add a mocked JWT test for the resource server #23

### DIFF
--- a/oauth2/resource/pom.xml
+++ b/oauth2/resource/pom.xml
@@ -37,6 +37,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
 			<scope>test</scope>

--- a/oauth2/resource/src/test/java/demo/ApplicationTests.java
+++ b/oauth2/resource/src/test/java/demo/ApplicationTests.java
@@ -2,22 +2,33 @@ package demo;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
 
 @SpringBootTest(webEnvironment=WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
 public class ApplicationTests {
 
 	@LocalServerPort
 	private int port;
 
 	private TestRestTemplate template = new TestRestTemplate();
+
+	@Autowired
+	private MockMvc mvc;
 
 	@Test
 	public void resourceLoads() {
@@ -26,4 +37,12 @@ public class ApplicationTests {
 		String auth = response.getHeaders().getFirst("WWW-Authenticate");
 		assertTrue(auth.startsWith("Bearer"), "Wrong header: " + auth);
 	}
+
+	@Test
+	public void resourceWhenJwtThenOk() throws Exception {
+		mvc.perform(get("/").with(jwt()))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.content").value("Hello World"));
+	}
+
 }


### PR DESCRIPTION
The resource server tests only covered anonymous 401. I added a MockMvc test that uses `jwt()` so a successful call does not need the authorization server.

`./mvnw -f oauth2/resource/pom.xml test -Dtest=ApplicationTests` is green.

Fixes #23
