### PR TITLE
Fix #184: add missing spring.application.name property

### DIFF
--- a/basic/src/main/resources/application.yml
+++ b/basic/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  application:
+    name: basic
   security:
     user:
       password: password


### PR DESCRIPTION
Fixes #184

The Basic application's application.yml was missing the
spring.application.name property.

Added:
spring.application.name: basic

This ensures the application has the required name for
Spring Security authentication configuration.